### PR TITLE
Fixing unit tests for Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": ">=5.4.0",
         "evenement/evenement": "~2.0",
         "react/event-loop": "0.4.*",
-        "react/stream": "0.4.*"
+        "react/stream": "0.4.*",
+		"phpunit/phpunit": "~4.0"
     },
     "require-dev": {
         "sebastian/environment": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
         "php": ">=5.4.0",
         "evenement/evenement": "~2.0",
         "react/event-loop": "0.4.*",
-        "react/stream": "0.4.*",
-		"phpunit/phpunit": "~4.0"
+        "react/stream": "0.4.*"
     },
     "require-dev": {
         "sebastian/environment": "~1.0"

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -71,7 +71,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $cmd = $this->getPhpCommandLine('echo getcwd(), PHP_EOL, count($_SERVER), PHP_EOL;');
 
         $loop = $this->createLoop();
-        $process = new Process($cmd);
+        $process = new Process($cmd, null, null, array("bypass_shell"=>true));
 
         $output = '';
         $error = '';
@@ -112,7 +112,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         }
 
         $loop = $this->createLoop();
-        $process = new Process($cmd, $testCwd);
+        $process = new Process($cmd, $testCwd, null, array("bypass_shell"=>true));
 
         $output = '';
 
@@ -143,7 +143,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         }
 
         $loop = $this->createLoop();
-        $process = new Process($cmd, null, array('foo' => 'bar'));
+        $process = new Process($cmd, null, array('foo' => 'bar'), array("bypass_shell"=>true));
 
         $output = '';
 
@@ -404,13 +404,6 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     private function getPhpCommandLine($phpCode)
     {
-        $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
-
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            // Windows madness! for some obscure reason, the whole command lines needs to be
-            // wrapped in quotes (?!?)
-            $cmd = '"'.$cmd.'"';
-        }
-        return $cmd;
+        return $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
     }
 }

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -69,21 +69,34 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testProcessWithDefaultCwdAndEnv()
     {
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getcwd(), PHP_EOL, count($_SERVER), PHP_EOL;');
-
+        
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+        
         $loop = $this->createLoop();
         $process = new Process($cmd);
 
         $output = '';
+        $error = '';
 
-        $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
+        $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output, &$error) {
             $process->start($timer->getLoop());
-            $process->stdout->on('data', function () use (&$output) {
-                $output .= func_get_arg(0);
+            $process->stdout->on('data', function ($data) use (&$output) {
+                $output .= $data;
+            });
+            $process->stderr->on('data', function ($data) use (&$error) {
+                $error .= $data;
             });
         });
 
         $loop->run();
-
+        
+        $this->assertEmpty($error);
+        $this->assertNotEmpty($output);
+        
         list($cwd, $envCount) = explode(PHP_EOL, $output);
 
         /* Child process should inherit the same current working directory and
@@ -98,8 +111,18 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getcwd(), PHP_EOL;');
 
+        $testCwd = '/';
+        
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+            
+            $testCwd = 'C:\\';
+        }
+         
         $loop = $this->createLoop();
-        $process = new Process($cmd, '/');
+        $process = new Process($cmd, $testCwd);
 
         $output = '';
 
@@ -112,7 +135,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $loop->run();
 
-        $this->assertSame('/' . PHP_EOL, $output);
+        $this->assertSame($testCwd . PHP_EOL, $output);
     }
 
     public function testProcessWithEnv()
@@ -123,6 +146,15 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getenv("foo"), PHP_EOL;');
 
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! escapeshellarg seems to completely remove double quotes in Windows!
+            // We need to use simple quotes in our PHP code!
+            $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getenv(\'foo\'), PHP_EOL;');
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+        
         $loop = $this->createLoop();
         $process = new Process($cmd, null, array('foo' => 'bar'));
 
@@ -173,6 +205,10 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testStartInvalidProcess()
     {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not have an executable flag. This test does not make sense on Windows.');     
+        }
+        
         $cmd = tempnam(sys_get_temp_dir(), 'react');
 
         $loop = $this->createLoop();
@@ -297,6 +333,51 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($process->getTermSignal());
         $this->assertFalse($process->isTerminated());
     }
+    
+    public function testProcessSmallOutput() {
+    	$this->processOutputOfSize(1000);
+    }
+    
+    public function testProcessMediumOutput() {
+    	$this->processOutputOfSize(10000);
+    }
+    
+    public function testProcessBigOutput() {
+    	$this->processOutputOfSize(100000);
+    }
+    
+    public function processOutputOfSize($size)
+    {
+    	// Note: very strange behaviour of Windows (PHP 5.5.6):
+    	// on a 1000 long string, Windows succeeds.
+    	// on a 10000 long string, Windows fails to output anything.
+    	// On a 100000 long string, it takes a lot of time but succeeds.
+        $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo str_repeat(\'o\', '.$size.'), PHP_EOL;');
+    
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+         
+        $loop = $this->createLoop();
+        $process = new Process($cmd);
+    
+        $output = '';
+    
+        $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
+            $process->start($timer->getLoop());
+            $process->stdout->on('data', function () use (&$output) {
+                $output .= func_get_arg(0);
+            });
+        });
+    
+        $loop->run();
+    
+        $this->assertEquals($size + strlen(PHP_EOL), strlen($output));
+        $this->assertSame(str_repeat('o', $size) . PHP_EOL, $output);
+    }
+    
 
     /**
      * Execute a callback at regular intervals until it returns successfully or

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -321,19 +321,14 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($process->isTerminated());
     }
 
-    public function testProcessSmallOutput() {
-    	$this->processOutputOfSize(1000);
+    public function outputSizeProvider() {
+        return [ [1000, 5], [10000, 5], [100000, 5] ];
     }
 
-    public function testProcessMediumOutput() {
-    	$this->processOutputOfSize(10000);
-    }
-
-    public function testProcessBigOutput() {
-    	$this->processOutputOfSize(100000);
-    }
-
-    public function processOutputOfSize($size, $expectedMaxDuration = 5)
+    /**
+     * @dataProvider outputSizeProvider
+     */
+    public function testProcessOutputOfSize($size, $expectedMaxDuration = 5)
     {
     	// Note: very strange behaviour of Windows (PHP 5.5.6):
     	// on a 1000 long string, Windows succeeds.
@@ -406,16 +401,16 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         return $runtime->getBinary();
     }
-    
+
     private function getPhpCommandLine($phpCode)
     {
-    	$cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
-    	
-    	if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-    		// Windows madness! for some obscure reason, the whole command lines needs to be
-    		// wrapped in quotes (?!?)
-    		$cmd = '"'.$cmd.'"';
-    	}
-    	return $cmd;
+        $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
+
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+        return $cmd;
     }
 }


### PR DESCRIPTION
Directly related to issue #9 that I opened yesterday, I've been working on Windows PHPUnit tests.

I fixed a number of those tests. Windows has a very very weird way to handle quotes when passed to the command line so I added a few tweaks to the unit tests so that quotes are handled correctly.

I managed to have all existing tests working on Windows.

But...

I added a few more tests that are working flawlessly on Linux, but failing on Windows.
Those tests are generating a big output (1000 / 10000 / 100000 characters).

This is where the fun starts. Output with 1000 works on Windows.
Output of 10000 fails (Windows outputs only 4096 characters)
Output of 100000 succeeds, but.... takes a whooping 32 seconds! (it takes less than 1 second on Linux)

Tests run with PHP 5.6.6.

Any idea of what might go wrong with Windows? I'm pretty sure it's related to Windows implementation of `proc_open` but I don't know how to prove it or how to fix it.