### PR TITLE
Windows fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,15 @@ process in a chain ends, which would complicate working with I/O streams. As an
 alternative, considering launching one process at a time and listening on its
 `exit` event to conditionally start the next process in the chain. This will
 give you an opportunity to configure the subsequent process' I/O streams.
+
+### Windows compatibility
+
+Windows has always had a poor `proc_open` implementation in PHP. Even if things 
+are better with the latest PHP versions, there are still a number of issues 
+when programs are outputing values to STDOUT or STDERR (truncated output,
+deadlocks, ...). To circumvent these problems, instead of relying on STDOUT 
+or STDERR, we write the output to files (in the temporary folder). This is an 
+implementation detail but it is important to be aware of it. Indeed, the output 
+of the command will be written to the disk, and even if the file is deleted at 
+the end of the process, writing the output to the disk might be a security 
+issues if the output contains sensitive data.

--- a/README.md
+++ b/README.md
@@ -105,3 +105,6 @@ implementation detail but it is important to be aware of it. Indeed, the output
 of the command will be written to the disk, and even if the file is deleted at 
 the end of the process, writing the output to the disk might be a security 
 issues if the output contains sensitive data.
+It could also be an issue with long lasting commands that are outputing a lot
+of data since the output file will grow until the process ends. This might
+fill the hard-drive if the process lasts long enough.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": ">=5.4.0",
         "evenement/evenement": "~2.0",
         "react/event-loop": "0.4.*",
-        "react/stream": "0.4.*"
+        "react/stream": "0.4.*",
+		"phpunit/phpunit": "~4.0"
     },
     "require-dev": {
         "sebastian/environment": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
         "php": ">=5.4.0",
         "evenement/evenement": "~2.0",
         "react/event-loop": "0.4.*",
-        "react/stream": "0.4.*",
-		"phpunit/phpunit": "~4.0"
+        "react/stream": "0.4.*"
     },
     "require-dev": {
         "sebastian/environment": "~1.0"

--- a/src/Process.php
+++ b/src/Process.php
@@ -132,7 +132,7 @@ class Process extends EventEmitter
      * @param float         $interval    Interval to periodically monitor process state (seconds)
      * @throws RuntimeException If the process is already running or fails to start
      */
-    public function startWindows(LoopInterface $loop, $interval = 0.1)
+    protected function startWindows(LoopInterface $loop, $interval = 0.1)
     {
         $cmd = $this->cmd;
         

--- a/src/UnstopableStream.php
+++ b/src/UnstopableStream.php
@@ -1,0 +1,38 @@
+<?php
+namespace React\ChildProcess;
+
+use React\Stream\Stream;
+use React\EventLoop\LoopInterface;
+
+/**
+ * This is a special kind of stream that does not end when reaching EOF.
+ * Useful for the Windows workaround of STDOUT and STDERR due to buggy PHP implementation.
+ */
+class UnstopableStream extends Stream
+{
+    private $filename;
+    
+    public function __construct($stream, LoopInterface $loop, $filename)
+    {
+        parent::__construct($stream, $loop);
+        $this->filename = $filename;    
+    }
+    
+    public function handleData($stream)
+    {
+        $data = fread($stream, $this->bufferSize);
+    
+        $this->emit('data', array($data, $this));
+    
+        // Let's not stop on feof
+        if (!is_resource($stream)) {
+            $this->end();
+        }
+    }
+
+    public function handleClose()
+    {
+        parent::handleClose();
+        unlink($this->filename);
+    }
+}

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -13,6 +13,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testGetEnhanceSigchildCompatibility()
     {
         $process = new Process('echo foo');
+        $process->useWindowsWorkaround();
 
         $this->assertSame($process, $process->setEnhanceSigchildCompatibility(true));
         $this->assertTrue($process->getEnhanceSigchildCompatibility());
@@ -27,6 +28,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testSetEnhanceSigchildCompatibilityCannotBeCalledIfProcessIsRunning()
     {
         $process = new Process('sleep 1');
+        $process->useWindowsWorkaround();
 
         $process->start($this->createLoop());
         $process->setEnhanceSigchildCompatibility(false);
@@ -35,6 +37,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testGetCommand()
     {
         $process = new Process('echo foo');
+        $process->useWindowsWorkaround();
 
         $this->assertSame('echo foo', $process->getCommand());
     }
@@ -42,6 +45,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testIsRunning()
     {
         $process = new Process('sleep 1');
+        $process->useWindowsWorkaround();
 
         $this->assertFalse($process->isRunning());
         $process->start($this->createLoop());
@@ -72,7 +76,8 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $loop = $this->createLoop();
         $process = new Process($cmd);
-
+        $process->useWindowsWorkaround();
+        
         $output = '';
         $error = '';
 
@@ -108,12 +113,13 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $testCwd = 'C:\\';
         } else {
-        	$testCwd = '/';
+            $testCwd = '/';
         }
 
         $loop = $this->createLoop();
         $process = new Process($cmd, $testCwd);
-
+        $process->useWindowsWorkaround();
+        
         $output = '';
 
         $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
@@ -144,7 +150,8 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $loop = $this->createLoop();
         $process = new Process($cmd, null, array('foo' => 'bar'));
-
+        $process->useWindowsWorkaround();
+        
         $output = '';
 
         $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
@@ -163,6 +170,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $loop = $this->createLoop();
         $process = new Process('exit 0');
+        $process->useWindowsWorkaround();
 
         $called = false;
         $exitCode = 'initial';
@@ -223,6 +231,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testStartAlreadyRunningProcess()
     {
         $process = new Process('sleep 1');
+        $process->useWindowsWorkaround();
 
         $process->start($this->createLoop());
         $process->start($this->createLoop());
@@ -280,6 +289,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $loop = $this->createloop();
         $process = new Process('sleep 1; exit 0');
+        $process->useWindowsWorkaround();
 
         $called = false;
         $exitCode = 'initial';
@@ -322,23 +332,23 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testProcessSmallOutput() {
-    	$this->processOutputOfSize(1000);
+        $this->processOutputOfSize(1000);
     }
 
     public function testProcessMediumOutput() {
-    	$this->processOutputOfSize(10000);
+        $this->processOutputOfSize(10000);
     }
 
     public function testProcessBigOutput() {
-    	$this->processOutputOfSize(100000);
+        $this->processOutputOfSize(100000);
     }
 
     public function processOutputOfSize($size, $expectedMaxDuration = 5)
     {
-    	// Note: very strange behaviour of Windows (PHP 5.5.6):
-    	// on a 1000 long string, Windows succeeds.
-    	// on a 10000 long string, Windows fails to output anything.
-    	// On a 100000 long string, it takes a lot of time but succeeds.
+        // Note: very strange behaviour of Windows (PHP 5.5.6):
+        // on a 1000 long string, Windows succeeds.
+        // on a 10000 long string, Windows fails to output anything.
+        // On a 100000 long string, it takes a lot of time but succeeds.
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo str_repeat(\'o\', '.$size.'), PHP_EOL;');
 
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
@@ -349,6 +359,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $loop = $this->createLoop();
         $process = new Process($cmd);
+        $process->useWindowsWorkaround();
 
         $output = '';
 
@@ -409,13 +420,13 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     
     private function getPhpCommandLine($phpCode)
     {
-    	$cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
-    	
-    	if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-    		// Windows madness! for some obscure reason, the whole command lines needs to be
-    		// wrapped in quotes (?!?)
-    		$cmd = '"'.$cmd.'"';
-    	}
-    	return $cmd;
+        $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
+        
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+        return $cmd;
     }
 }

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -75,7 +75,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $cmd = $this->getPhpCommandLine('echo getcwd(), PHP_EOL, count($_SERVER), PHP_EOL;');
 
         $loop = $this->createLoop();
-        $process = new Process($cmd);
+        $process = new Process($cmd, null, null, array("bypass_shell"=>true));
         $process->useWindowsWorkaround();
 
         $output = '';
@@ -117,7 +117,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         }
 
         $loop = $this->createLoop();
-        $process = new Process($cmd, $testCwd);
+        $process = new Process($cmd, $testCwd, null, array("bypass_shell"=>true));
         $process->useWindowsWorkaround();
 
         $output = '';
@@ -149,7 +149,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         }
 
         $loop = $this->createLoop();
-        $process = new Process($cmd, null, array('foo' => 'bar'));
+        $process = new Process($cmd, null, array('foo' => 'bar'), array("bypass_shell"=>true));
         $process->useWindowsWorkaround();
 
         $output = '';
@@ -415,13 +415,6 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     private function getPhpCommandLine($phpCode)
     {
-        $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
-
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            // Windows madness! for some obscure reason, the whole command lines needs to be
-            // wrapped in quotes (?!?)
-            $cmd = '"'.$cmd.'"';
-        }
-        return $cmd;
+        return $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
     }
 }

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -77,7 +77,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $loop = $this->createLoop();
         $process = new Process($cmd);
         $process->useWindowsWorkaround();
-        
+
         $output = '';
         $error = '';
 
@@ -119,7 +119,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $loop = $this->createLoop();
         $process = new Process($cmd, $testCwd);
         $process->useWindowsWorkaround();
-        
+
         $output = '';
 
         $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
@@ -151,7 +151,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $loop = $this->createLoop();
         $process = new Process($cmd, null, array('foo' => 'bar'));
         $process->useWindowsWorkaround();
-        
+
         $output = '';
 
         $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
@@ -331,19 +331,14 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($process->isTerminated());
     }
 
-    public function testProcessSmallOutput() {
-        $this->processOutputOfSize(1000);
+    public function outputSizeProvider() {
+        return [ [1000, 5], [10000, 5], [100000, 5] ];
     }
 
-    public function testProcessMediumOutput() {
-        $this->processOutputOfSize(10000);
-    }
-
-    public function testProcessBigOutput() {
-        $this->processOutputOfSize(100000);
-    }
-
-    public function processOutputOfSize($size, $expectedMaxDuration = 5)
+    /**
+     * @dataProvider outputSizeProvider
+     */
+    public function testProcessOutputOfSize($size, $expectedMaxDuration = 5)
     {
         // Note: very strange behaviour of Windows (PHP 5.5.6):
         // on a 1000 long string, Windows succeeds.
@@ -417,11 +412,11 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         return $runtime->getBinary();
     }
-    
+
     private function getPhpCommandLine($phpCode)
     {
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg($phpCode);
-        
+
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             // Windows madness! for some obscure reason, the whole command lines needs to be
             // wrapped in quotes (?!?)

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -69,21 +69,34 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testProcessWithDefaultCwdAndEnv()
     {
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getcwd(), PHP_EOL, count($_SERVER), PHP_EOL;');
-
+        
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+        
         $loop = $this->createLoop();
         $process = new Process($cmd);
 
         $output = '';
+        $error = '';
 
-        $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
+        $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output, &$error) {
             $process->start($timer->getLoop());
-            $process->stdout->on('data', function () use (&$output) {
-                $output .= func_get_arg(0);
+            $process->stdout->on('data', function ($data) use (&$output) {
+                $output .= $data;
+            });
+            $process->stderr->on('data', function ($data) use (&$error) {
+                $error .= $data;
             });
         });
 
         $loop->run();
-
+        
+        $this->assertEmpty($error);
+        $this->assertNotEmpty($output);
+        
         list($cwd, $envCount) = explode(PHP_EOL, $output);
 
         /* Child process should inherit the same current working directory and
@@ -98,8 +111,18 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getcwd(), PHP_EOL;');
 
+        $testCwd = '/';
+        
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+            
+            $testCwd = 'C:\\';
+        }
+         
         $loop = $this->createLoop();
-        $process = new Process($cmd, '/');
+        $process = new Process($cmd, $testCwd);
 
         $output = '';
 
@@ -112,7 +135,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $loop->run();
 
-        $this->assertSame('/' . PHP_EOL, $output);
+        $this->assertSame($testCwd . PHP_EOL, $output);
     }
 
     public function testProcessWithEnv()
@@ -123,6 +146,15 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getenv("foo"), PHP_EOL;');
 
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! escapeshellarg seems to completely remove double quotes in Windows!
+            // We need to use simple quotes in our PHP code!
+            $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo getenv(\'foo\'), PHP_EOL;');
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+        
         $loop = $this->createLoop();
         $process = new Process($cmd, null, array('foo' => 'bar'));
 
@@ -173,6 +205,10 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testStartInvalidProcess()
     {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not have an executable flag. This test does not make sense on Windows.');     
+        }
+        
         $cmd = tempnam(sys_get_temp_dir(), 'react');
 
         $loop = $this->createLoop();
@@ -297,6 +333,51 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($process->getTermSignal());
         $this->assertFalse($process->isTerminated());
     }
+    
+    public function testProcessSmallOutput() {
+    	$this->processOutputOfSize(1000);
+    }
+    
+    public function testProcessMediumOutput() {
+    	$this->processOutputOfSize(10000);
+    }
+    
+    public function testProcessBigOutput() {
+    	$this->processOutputOfSize(100000);
+    }
+    
+    public function processOutputOfSize($size)
+    {
+    	// Note: very strange behaviour of Windows (PHP 5.5.6):
+    	// on a 1000 long string, Windows succeeds.
+    	// on a 10000 long string, Windows fails to output anything.
+    	// On a 100000 long string, it takes a lot of time but succeeds.
+        $cmd = $this->getPhpBinary() . ' -r ' . escapeshellarg('echo str_repeat(\'o\', '.$size.'), PHP_EOL;');
+    
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Windows madness! for some obscure reason, the whole command lines needs to be
+            // wrapped in quotes (?!?)
+            $cmd = '"'.$cmd.'"';
+        }
+         
+        $loop = $this->createLoop();
+        $process = new Process($cmd);
+    
+        $output = '';
+    
+        $loop->addTimer(0.001, function(Timer $timer) use ($process, &$output) {
+            $process->start($timer->getLoop());
+            $process->stdout->on('data', function () use (&$output) {
+                $output .= func_get_arg(0);
+            });
+        });
+    
+        $loop->run();
+    
+        $this->assertEquals($size + strlen(PHP_EOL), strlen($output));
+        $this->assertSame(str_repeat('o', $size) . PHP_EOL, $output);
+    }
+    
 
     /**
      * Execute a callback at regular intervals until it returns successfully or


### PR DESCRIPTION
Another Windows related pull-request.

I tried to fix the bugs that are related to STDOUT containing about 4096 instead of 10000 and Windows hanging for 32 seconds before returning a 100000 charcters output.
To circumvent the STDOUT / STDERR problem, I redirect the output and error of the program to a file.
This file is read by a stream. Of course, this is a Windows only workaround.

This works great, but has a security impact, since stdout and stderr are written to the disk. It is also an issue for long running processes, since those could fill the hard-drive fairly quickly.
Files are automatically deleted at the end of the process, but of course, things can go wrong in which case file won't be deleted.

So this is definitely not the perfect workaround, but at least, it makes child-process usable in Windows while waiting a fix in PHP, if it ever comes (the issue has been open for quite a few years).

What do you think about this?
