### PR TITLE
Don't wait for a timer when the process already died

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -110,7 +110,7 @@ class Process extends EventEmitter
                 return;
             }
 
-            $loop->addPeriodicTimer($interval, function (TimerInterface $timer) {
+            $loop->addPeriodicTimer($this->isRunning() ? $interval : 0, function (TimerInterface $timer) {
                 if (!$this->isRunning()) {
                     $this->close();
                     $timer->cancel();


### PR DESCRIPTION
Currently, the 'exit' event occurs only after some time defined by a periodic timer.
This means a react child-process can't be faster than this timer.
Using this patch, the exit even is triggered as soon as the process exits, which can be way earlier than what is done today.
