### PR TITLE
AppVeyor config to run tests on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,40 @@
+build: false
+platform:
+  - x86
+  - x64
+clone_folder: c:\projects\reactphp-child-process
+
+## Cache composer bits
+cache:
+    - c:\tools\php -> appveyor.yml
+    - c:\projects\reactphp-child-process\vendor -> composer.lock
+    - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+
+## Set up environment varriables
+init:
+    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+
+## Install PHP and composer, and run the appropriate composer command
+install:
+    - IF EXIST c:\tools\php (SET PHP=0)
+    - IF %PHP%==1 cinst -y OpenSSL.Light
+    - IF %PHP%==1 cinst -y php
+    - cd c:\tools\php
+    - IF %PHP%==1 copy php.ini-production php.ini /Y
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - cd c:\projects\reactphp-child-process
+    - composer install --no-progress
+
+## Run the actual test
+test_script:
+    - cd c:\projects\reactphp-child-process
+    - vendor/bin/phpunit -c phpunit.xml.dist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ install:
     - appveyor DownloadFile https://getcomposer.org/composer.phar
     - cd c:\projects\reactphp-child-process
     - composer install --no-progress
+    - composer require phpunit/phpunit
 
 ## Run the actual test
 test_script:


### PR DESCRIPTION
#11 and #13 propose Windows compatibility but we can't actually test those on travis. [AppVeyor](http://www.appveyor.com/) is a hosted CI like Travis but for windows, they're free for OSS projects like Travis. This config files sets up PHP on windows and runs the tests on them. Just like travis it does require someone to add the project to AppVeyor.