### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "keywords": ["process"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "evenement/evenement": "~2.0",
-        "react/event-loop": "0.4.*",
+        "php": ">=5.3.0",
+        "evenement/evenement": "^2.0 || ^1.0",
+        "react/event-loop": "^0.4 || ^0.3",
         "react/stream": "^0.5 || ^0.4.4"
     },
     "require-dev": {

--- a/src/Process.php
+++ b/src/Process.php
@@ -126,6 +126,13 @@ class Process extends EventEmitter
         $this->stdout->on('close', $streamCloseHandler);
         $this->stderr = new Stream($this->pipes[2], $loop);
         $this->stderr->on('close', $streamCloseHandler);
+
+        // legacy PHP < 5.4 SEGFAULTs for unbuffered, non-blocking reads
+        // work around by enabling read buffer again
+        if (PHP_VERSION_ID < 50400) {
+            stream_set_read_buffer($this->pipes[1], 1);
+            stream_set_read_buffer($this->pipes[2], 1);
+        }
     }
 
     /**

--- a/src/Process.php
+++ b/src/Process.php
@@ -103,21 +103,21 @@ class Process extends EventEmitter
 
         $closeCount = 0;
 
-        $streamCloseHandler = function () use (&$closeCount, $loop, $interval) {
+        $that = $this;
+        $streamCloseHandler = function () use (&$closeCount, $loop, $interval, $that) {
             $closeCount++;
 
             if ($closeCount < 2) {
                 return;
             }
 
-            $loop->addPeriodicTimer($interval, function (TimerInterface $timer) {
-                if (!$this->isRunning()) {
-                    $this->close();
+            $loop->addPeriodicTimer($interval, function (TimerInterface $timer) use ($that) {
+                if (!$that->isRunning()) {
+                    $that->close();
                     $timer->cancel();
-                    $this->emit('exit', array($this->getExitCode(), $this->getTermSignal()));
+                    $that->emit('exit', array($that->getExitCode(), $that->getTermSignal()));
                 }
             });
-
         };
 
         $this->stdin  = new Stream($this->pipes[0], $loop);

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -268,21 +268,22 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
             $termSignal = func_get_arg(1);
         });
 
-        $loop->addTimer(0.001, function(Timer $timer) use ($process) {
+        $that = $this;
+        $loop->addTimer(0.001, function(Timer $timer) use ($process, $that) {
             $process->start($timer->getLoop());
             $process->terminate(SIGSTOP);
 
-            $this->assertSoon(function() use ($process) {
-                $this->assertTrue($process->isStopped());
-                $this->assertTrue($process->isRunning());
-                $this->assertEquals(SIGSTOP, $process->getStopSignal());
+            $that->assertSoon(function() use ($process, $that) {
+                $that->assertTrue($process->isStopped());
+                $that->assertTrue($process->isRunning());
+                $that->assertEquals(SIGSTOP, $process->getStopSignal());
             });
 
             $process->terminate(SIGCONT);
 
-            $this->assertSoon(function() use ($process) {
-                $this->assertFalse($process->isStopped());
-                $this->assertEquals(SIGSTOP, $process->getStopSignal());
+            $that->assertSoon(function() use ($process, $that) {
+                $that->assertFalse($process->isStopped());
+                $that->assertEquals(SIGSTOP, $process->getStopSignal());
             });
         });
 
@@ -308,12 +309,13 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $stdOut = '';
         $stdErr = '';
 
+        $that = $this;
         $process->on(
             'exit',
-            function ($exitCode) use (&$stdOut, &$stdErr, $testString) {
-                $this->assertEquals(0, $exitCode, "Exit code is 0");
+            function ($exitCode) use (&$stdOut, &$stdErr, $testString, $that) {
+                $that->assertEquals(0, $exitCode, "Exit code is 0");
 
-                $this->assertEquals($testString, $stdOut);
+                $that->assertEquals($testString, $stdOut);
             }
         );
 


### PR DESCRIPTION
Because _why not_… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting _significant amount_ of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually _require_ any new language features or some external lib, then I'm all for dropping support again.
