### PR TITLE
Added a note about windows compatibility to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,11 @@ of the actual exit code.
 
 ### Windows Compatibility
 
-Due to the blocking nature of `STDIN`/`STDOUT`/`STDERR` pipes on windows we cannot 
-guarantee this package works as expected on directly windows. However this package 
+Due to the blocking nature of `STDIN`/`STDOUT`/`STDERR` pipes on Windows we we can 
+not guarantee this package works as expected on Windows directly. However this package 
 does work on [`Windows Subsystem for Linux`](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) 
 (or WSL) without issues. We suggest [installing WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) 
-when you want to run this package on windows.
+when you want to run this package on Windows.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ as [Streams](https://github.com/reactphp/stream).
   * [Stream Properties](#stream-properties)
   * [Command](#command)
   * [Sigchild Compatibility](#sigchild-compatibility)
+  * [Windows Compatibility](#windows-compatibility)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ of the actual exit code.
 **Note:** This functionality was taken from Symfony's
 [Process](https://github.com/symfony/process) compoment.
 
+### Windows Compatibility
+
+Due to the blocking nature of `STDIN`/`STDOUT`/`STDERR` pipes on windows we cannot 
+guarantee this package works as expected on directly windows. However this package 
+does work on [`Windows Subsystem for Linux`](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) 
+(or WSL) without issues. We suggest [installing WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) 
+when you want to run this package on windows.
+
 ## Install
 
 The recommended way to install this library is [through Composer](http://getcomposer.org).


### PR DESCRIPTION
Due to changes in `react/stream` we cannot guarantee native windows anymore. Added a note about it in the `readme`.