### PR TITLE
Documentation and examples for process termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ as [Streams](https://github.com/reactphp/stream).
 **Table of contents**
 
 * [Quickstart example](#quickstart-example)
-* [Processes](#processes)
-  * [Methods](#methods)
+* [Process](#process)
   * [Stream Properties](#stream-properties)
   * [Command](#command)
   * [Termination](#termination)
@@ -46,16 +45,7 @@ $loop->run();
 
 See also the [examples](examples).
 
-## Processes
-
-### Methods
-
-* `start()`: Launches the process and registers its IO streams with the event
-  loop. The stdin stream will be left in a paused state.
-* `terminate()`: Send the process a signal (SIGTERM by default).
-
-There are additional public methods on the Process class, which may be used to
-access fields otherwise available through `proc_get_status()`.
+## Process
 
 ### Stream Properties
 
@@ -105,6 +95,7 @@ The `Process` class allows you to pass any kind of command line string:
 
 ```php
 $process = new Process('echo test');
+$process->start($loop);
 ```
 
 By default, PHP will launch processes by wrapping the given command line string
@@ -120,6 +111,7 @@ streams from the wrapping shell command like this:
 
 ```php
 $process = new Process('echo run && demo || echo failed');
+$process->start($loop);
 ```
 
 In other words, the underlying shell is responsible for managing this command
@@ -135,6 +127,7 @@ boundary between each sub-command like this:
 
 ```php
 $process = new Process('cat first && echo --- && cat second');
+$process->start($loop);
 ```
 
 As an alternative, considering launching one process at a time and listening on
@@ -157,6 +150,7 @@ also applies to running the most simple single command:
 
 ```php
 $process = new Process('yes');
+$process->start($loop);
 ```
 
 This will actually spawn a command hierarchy similar to this:
@@ -177,6 +171,7 @@ process to be replaced by our process:
 
 ```php
 $process = new Process('exec yes');
+$process->start($loop);
 ```
 
 This will show a resulting command hierarchy similar to this:

--- a/examples/04-terminate.php
+++ b/examples/04-terminate.php
@@ -1,0 +1,27 @@
+<?php
+
+use React\EventLoop\Factory;
+use React\ChildProcess\Process;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+
+// start a process that takes 10s to terminate
+$process = new Process('sleep 10');
+$process->start($loop);
+
+// report when process exits
+$process->on('exit', function ($exit, $term) {
+    var_dump($exit, $term);
+});
+
+// forcefully terminate process after 2s
+$loop->addTimer(2.0, function () use ($process) {
+    $process->stdin->close();
+    $process->stdout->close();
+    $process->stderr->close();
+    $process->terminate();
+});
+
+$loop->run();

--- a/src/Process.php
+++ b/src/Process.php
@@ -181,6 +181,10 @@ class Process extends EventEmitter
      */
     public function terminate($signal = null)
     {
+        if ($this->process === null) {
+            return false;
+        }
+
         if ($signal !== null) {
             return proc_terminate($this->process, $signal);
         }

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -284,6 +284,13 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $process->start($this->createLoop());
     }
 
+    public function testTerminateProcesWithoutStartingReturnsFalse()
+    {
+        $process = new Process('sleep 1');
+
+        $this->assertFalse($process->terminate());
+    }
+
     public function testTerminateWithDefaultTermSignalUsingEventLoop()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -291,6 +291,28 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($process->terminate());
     }
 
+    public function testTerminateWillExit()
+    {
+        $loop = $this->createloop();
+
+        $process = new Process('sleep 10');
+        $process->start($loop);
+
+        $called = false;
+        $process->on('exit', function () use (&$called) {
+            $called = true;
+        });
+
+        $process->stdin->close();
+        $process->stdout->close();
+        $process->stderr->close();
+        $process->terminate();
+
+        $loop->run();
+
+        $this->assertTrue($called);
+    }
+
     public function testTerminateWithDefaultTermSignalUsingEventLoop()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {


### PR DESCRIPTION
Process termination is (slighty) more complicated than merely "killing" a process, let's add some documentation and try to cover the nasty details. This also adds examples and tests for this and fixes a minor issue when trying to terminate a process that is not running (any more) in the first place.