### PR TITLE
Throw LogicException on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,10 @@ of the actual exit code.
 
 ### Windows Compatibility
 
-Due to the blocking nature of `STDIN`/`STDOUT`/`STDERR` pipes on Windows we we can 
-not guarantee this package works as expected on Windows directly. However this package 
-does work on [`Windows Subsystem for Linux`](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) 
+Due to the blocking nature of `STDIN`/`STDOUT`/`STDERR` pipes on Windows we can 
+not guarantee this package works as expected on Windows directly. As such when 
+instantiating `Process` it throws an exception when on native Windows. 
+However this package does work on [`Windows Subsystem for Linux`](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) 
 (or WSL) without issues. We suggest [installing WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) 
 when you want to run this package on Windows.
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -45,10 +45,15 @@ class Process extends EventEmitter
     * @param string $cwd     Current working directory or null to inherit
     * @param array  $env     Environment variables or null to inherit
     * @param array  $options Options for proc_open()
+    * @throws LogicException On windows
     * @throws RuntimeException When proc_open() is not installed
     */
     public function __construct($cmd, $cwd = null, array $env = null, array $options = array())
     {
+        if (substr(strtolower(PHP_OS), 0, 3) === 'win') {
+            throw new \LogicException('Windows isn\'t supported due to the blocking nature of STDIN/STDOUT/STDERR pipes.');
+        }
+
         if (!function_exists('proc_open')) {
             throw new \RuntimeException('The Process class relies on proc_open(), which is not available on your PHP installation.');
         }


### PR DESCRIPTION
Since pipes Windows always block this PR introduces always throwing an exception so we don't allocate unnecessary resources.

Follows up #41 