### PR TITLE
Remove now unneeded buffer workaround for legacy PHP < 5.4

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -130,13 +130,6 @@ class Process extends EventEmitter
         $this->stdout->on('close', $streamCloseHandler);
         $this->stderr = new ReadableResourceStream($this->pipes[2], $loop);
         $this->stderr->on('close', $streamCloseHandler);
-
-        // legacy PHP < 5.4 SEGFAULTs for unbuffered, non-blocking reads
-        // work around by enabling read buffer again
-        if (PHP_VERSION_ID < 50400) {
-            stream_set_read_buffer($this->pipes[1], 1);
-            stream_set_read_buffer($this->pipes[2], 1);
-        }
     }
 
     /**


### PR DESCRIPTION
The code below has been introduced via #29 to work around an issue for legacy PHP < 5.4 only, but was later fixed upstream in the Stream component via https://github.com/reactphp/stream/pull/80 which later landed here via https://github.com/reactphp/child-process/pull/38 so that this work around is no longer needed here :+1: 

This is merely a code cleanup because this code is in fact no longer needed and has zero effect right now (this is covered by the tests introduced via #29). A similar (but unrelated) issue has been raised in #40 which I'd like to address separately once we try to reproduce this. For the reference: The original issue boils down to an issue in PHP itself and it's very likely we'll see something similar here: https://github.com/reactphp/stream/issues/78