### PR TITLE
Update Stream dependency to work around SEGFAULT in legacy PHP < 5.4.28 and PHP < 5.5.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/stream": "^1.0 || ^0.7.2"
+        "react/stream": "^1.0 || ^0.7.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8.10",


### PR DESCRIPTION
We've been able to track this back to legacy PHP bug https://bugs.php.net/bug.php?id=61019 which was fixed via php/php-src@1ec83d4.

This update simply applies the upstream work around to avoid switching to unbuffered mode for pipe streams on PHP < 5.4.28 and PHP < 5.5.12 and thus avoids this issue on all versions. Technically, unbuffered reads aren't really needed here for any PHP version, but not using unbuffered reads shows a 10%-20% performance penalty.

Resolves / closes #40
Refs https://github.com/reactphp/stream/pull/126
Builds on top of #50