### PR TITLE
Detect exit immediately if last process pipe is closed

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -115,10 +115,18 @@ class Process extends EventEmitter
                 return;
             }
 
+            // process already closed => report immediately
+            if (!$that->isRunning()) {
+                $that->close();
+                $that->emit('exit', array($that->getExitCode(), $that->getTermSignal()));
+                return;
+            }
+
+            // close not detected immediately => check regularly
             $loop->addPeriodicTimer($interval, function ($timer) use ($that, $loop) {
                 if (!$that->isRunning()) {
-                    $that->close();
                     $loop->cancelTimer($timer);
+                    $that->close();
                     $that->emit('exit', array($that->getExitCode(), $that->getTermSignal()));
                 }
             });


### PR DESCRIPTION
This PR introduces a simple check to see if the program is already known to be closed when the last process pipe is closed. This simple change improves "exit" detection significantly for most programs and does not cause a noticeable penalty for more advanced use cases.

Most programs do not explicitly close their STDIO handles and these will be closed implicitly when the program exits. Accordingly, we will now detect the "exit" event immediately without having to start a timer.

More advanced programs may close their STDIO handles explicitly while the program is still running. We continue to use a perodic timer to check the program state in this case.

Supersedes / closes #15, thanks @nicolas-grekas!