### PR TITLE
Improve sigchild compatibility and support explicit configuration

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -64,7 +64,7 @@ class Process extends EventEmitter
             }
         }
 
-        $this->enhanceSigchildCompatibility = $this->isSigchildEnabled();
+        $this->enhanceSigchildCompatibility = self::isSigchildEnabled();
     }
 
     /**
@@ -91,7 +91,7 @@ class Process extends EventEmitter
         );
 
         // Read exit code through fourth pipe to work around --enable-sigchild
-        if ($this->isSigchildEnabled() && $this->enhanceSigchildCompatibility) {
+        if ($this->enhanceSigchildCompatibility) {
             $fdSpec[] = array('pipe', 'w');
             $cmd = sprintf('(%s) 3>/dev/null; code=$?; echo $code >&3; exit $code', $cmd);
         }
@@ -152,7 +152,7 @@ class Process extends EventEmitter
         $this->stdout->close();
         $this->stderr->close();
 
-        if ($this->isSigchildEnabled() && $this->enhanceSigchildCompatibility) {
+        if ($this->enhanceSigchildCompatibility) {
             $this->pollExitCodePipe();
             $this->closeExitCodePipe();
         }
@@ -201,38 +201,6 @@ class Process extends EventEmitter
     public function getCommand()
     {
         return $this->cmd;
-    }
-
-    /**
-     * Return whether sigchild compatibility is enabled.
-     *
-     * @return boolean
-     */
-    public final function getEnhanceSigchildCompatibility()
-    {
-        return $this->enhanceSigchildCompatibility;
-    }
-
-    /**
-     * Enable or disable sigchild compatibility mode.
-     *
-     * Sigchild compatibility mode is required to get the exit code and
-     * determine the success of a process when PHP has been compiled with
-     * the --enable-sigchild option.
-     *
-     * @param boolean $enhance
-     * @return self
-     * @throws RuntimeException If the process is already running
-     */
-    public final function setEnhanceSigchildCompatibility($enhance)
-    {
-        if ($this->isRunning()) {
-            throw new \RuntimeException('Process is already running');
-        }
-
-        $this->enhanceSigchildCompatibility = (bool) $enhance;
-
-        return $this;
     }
 
     /**
@@ -345,6 +313,21 @@ class Process extends EventEmitter
         phpinfo(INFO_GENERAL);
 
         return self::$sigchild = false !== strpos(ob_get_clean(), '--enable-sigchild');
+    }
+
+    /**
+     * Enable or disable sigchild compatibility mode.
+     *
+     * Sigchild compatibility mode is required to get the exit code and
+     * determine the success of a process when PHP has been compiled with
+     * the --enable-sigchild option.
+     *
+     * @param boolean $sigchild
+     * @return void
+     */
+    public final static function setSigchildEnabled($sigchild)
+    {
+        self::$sigchild = (bool) $sigchild;
     }
 
     /**

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -11,28 +11,6 @@ abstract class AbstractProcessTest extends TestCase
 {
     abstract public function createLoop();
 
-    public function testGetEnhanceSigchildCompatibility()
-    {
-        $process = new Process('echo foo');
-
-        $this->assertSame($process, $process->setEnhanceSigchildCompatibility(true));
-        $this->assertTrue($process->getEnhanceSigchildCompatibility());
-
-        $this->assertSame($process, $process->setEnhanceSigchildCompatibility(false));
-        $this->assertFalse($process->getEnhanceSigchildCompatibility());
-    }
-
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testSetEnhanceSigchildCompatibilityCannotBeCalledIfProcessIsRunning()
-    {
-        $process = new Process('sleep 1');
-
-        $process->start($this->createLoop());
-        $process->setEnhanceSigchildCompatibility(false);
-    }
-
     public function testGetCommand()
     {
         $process = new Process('echo foo');
@@ -65,6 +43,20 @@ abstract class AbstractProcessTest extends TestCase
     public function testGetTermSignalWhenRunning($process)
     {
         $this->assertNull($process->getTermSignal());
+    }
+
+    public function testCommandWithEnhancedSigchildCompatibilityReceivesExitCode()
+    {
+        $loop = $this->createLoop();
+        $old = Process::isSigchildEnabled();
+        Process::setSigchildEnabled(true);
+        $process = new Process('echo foo');
+        $process->start($loop);
+        Process::setSigchildEnabled($old);
+
+        $loop->run();
+
+        $this->assertEquals(0, $process->getExitCode());
     }
 
     public function testReceivesProcessStdoutFromEcho()


### PR DESCRIPTION
This PR improves sigchild compatibility and adds support for explicit configuration in case automatic sigchild detection fails or the overhead incurred by the sigchild compatibility mode is not wanted. Note that this includes a small BC break because some of the old public sigchild methods have been removed, but its practical impact is believed to be relatively small due to the automatic detection.

Resolves / closes #60 