### PR TITLE
Support passing custom pipes and file descriptors to child process

### DIFF
--- a/examples/21-fds.php
+++ b/examples/21-fds.php
@@ -1,0 +1,23 @@
+<?php
+
+use React\EventLoop\Factory;
+use React\ChildProcess\Process;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+
+$process = new Process('exec 0>&- 2>&-;exec ls -la /proc/self/fd', null, null, array(
+    1 => array('pipe', 'w')
+));
+$process->start($loop);
+
+$process->stdout->on('data', function ($chunk) {
+    echo $chunk;
+});
+
+$process->on('exit', function ($code) {
+    echo 'EXIT with code ' . $code . PHP_EOL;
+});
+
+$loop->run();


### PR DESCRIPTION
This PR adds support for passing custom pipes and file descriptors to child processes. This is considered advanced usage and will only be used when explicitly configured during construction. Additionally, this is a prerequisite for Windows support (#9).

Builds on top of #64
Resolves / closes #12