### PR TITLE
Test against PHP7.2 and PHP 7.3, improve HHVM compatibility and add forward compatibility with PHPUnit 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm # ignore errors, see below
+  - 7.2
+  - 7.3
+# - hhvm # requires legacy phpunit & ignore errors, see below
 
 # lock distro so new future defaults will not break the build
 dist: trusty
@@ -16,6 +18,8 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: hhvm
+      install: composer require phpunit/phpunit:^5 --dev --no-interaction
   allow_failures:
     - php: hhvm
 
@@ -23,7 +27,7 @@ sudo: false
 
 install:
   - composer install --no-interaction
-  
+
 script:
   - vendor/bin/phpunit --coverage-text
   - php examples/13-benchmark-throughput.php

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "react/stream": "^1.0 || ^0.7.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35",
+        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35",
         "sebastian/environment": "^3.0 || ^2.0 || ^1.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>

--- a/src/Process.php
+++ b/src/Process.php
@@ -180,8 +180,7 @@ class Process extends EventEmitter
         }
 
         foreach ($pipes as $n => $fd) {
-            $meta = \stream_get_meta_data($fd);
-            if (\strpos($meta['mode'], 'w') !== false) {
+            if (\strpos($this->fds[$n][1], 'w') === false) {
                 $stream = new WritableResourceStream($fd, $loop);
             } else {
                 $stream = new ReadableResourceStream($fd, $loop);

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -308,12 +308,13 @@ abstract class AbstractProcessTest extends TestCase
         $process->start($loop);
 
         $closed = false;
-        $process->stdout->on('close', function () use (&$closed) {
+        $process->stdout->on('close', function () use (&$closed, $loop) {
             $closed = true;
+            $loop->stop();
         });
 
-        // run loop for 0.1s only
-        $loop->addTimer(0.1, function () use ($loop) {
+        // run loop for maximum of 0.5s only
+        $loop->addTimer(0.5, function () use ($loop) {
             $loop->stop();
         });
         $loop->run();
@@ -330,15 +331,21 @@ abstract class AbstractProcessTest extends TestCase
         $process->start($loop);
 
         $closed = 0;
-        $process->stdout->on('close', function () use (&$closed) {
+        $process->stdout->on('close', function () use (&$closed, $loop) {
             ++$closed;
+            if ($closed === 2) {
+                $loop->stop();
+            }
         });
-        $process->stderr->on('close', function () use (&$closed) {
+        $process->stderr->on('close', function () use (&$closed, $loop) {
             ++$closed;
+            if ($closed === 2) {
+                $loop->stop();
+            }
         });
 
-        // run loop for 0.1s only
-        $loop->addTimer(0.1, function () use ($loop) {
+        // run loop for maximum 0.5s only
+        $loop->addTimer(0.5, function () use ($loop) {
             $loop->stop();
         });
         $loop->run();
@@ -359,7 +366,7 @@ abstract class AbstractProcessTest extends TestCase
         $loop->run();
         $time = microtime(true) - $time;
 
-        $this->assertLessThan(0.1, $time);
+        $this->assertLessThan(0.5, $time);
         $this->assertSame(0, $process->getExitCode());
     }
 


### PR DESCRIPTION
Additionally, use legacy PHPUnit 5 for legacy HHVM on Travis CI as per
https://github.com/clue/php-socket-raw/pull/42

Builds on top of #54