### PR TITLE
Support spawning child process on Windows without process I/O pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ array with all three pipes.
 
 Note that this default configuration may be overridden by explicitly passing
 [custom pipes](#custom-pipes), in which case they may not be set or be assigned
-different values. The `$pipes` array will always contain references to all pipes
-as configured and the standard I/O references will always be set to reference
-the pipes matching the above conventions. See [custom pipes](#custom-pipes) for
-more details.
+different values. In particular, note that [Windows support](#windows-compatibility)
+is limited in that it doesn't support non-blocking STDIO pipes. The `$pipes`
+array will always contain references to all pipes as configured and the standard
+I/O references will always be set to reference the pipes matching the above
+conventions. See [custom pipes](#custom-pipes) for more details.
 
 Because each of these implement the underlying
 [`ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface) or 
@@ -116,8 +117,9 @@ $process->start($loop);
 ```
 
 By default, PHP will launch processes by wrapping the given command line string
-in a `sh` command, so that the above example will actually execute
-`sh -c echo test` under the hood.
+in a `sh` command on Unix, so that the above example will actually execute
+`sh -c echo test` under the hood on Unix. On Windows, it will launch processes
+by wrapping it in a `cmd` shell like `cmd /C echo test`.
 
 This is a very useful feature because it does not only allow you to pass single
 commands, but actually allows you to pass any kind of shell command line and
@@ -183,8 +185,8 @@ will actually target the wrapping shell, which may not be the desired result
 in many cases.
 
 If you do not want this wrapping shell process to show up, you can simply
-prepend the command string with `exec`, which will cause the wrapping shell
-process to be replaced by our process:
+prepend the command string with `exec` on Unix platforms, which will cause the
+wrapping shell process to be replaced by our process:
 
 ```php
 $process = new Process('exec yes');
@@ -209,8 +211,8 @@ As a rule of thumb, most commands will likely run just fine with the wrapping
 shell.
 If you pass a complete command line (or are unsure), you SHOULD most likely keep
 the wrapping shell.
-If you want to pass an invidual command only, you MAY want to consider
-prepending the command string with `exec` to avoid the wrapping shell.
+If you're running on Unix and you want to pass an invidual command only, you MAY
+want to consider prepending the command string with `exec` to avoid the wrapping shell.
 
 ### Termination
 
@@ -396,12 +398,132 @@ cases. You may then enable this  explicitly as given above.
 
 ### Windows Compatibility
 
-Due to the blocking nature of `STDIN`/`STDOUT`/`STDERR` pipes on Windows we can 
-not guarantee this package works as expected on Windows directly. As such when 
-instantiating `Process` it throws an exception when on native Windows. 
-However this package does work on [`Windows Subsystem for Linux`](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) 
-(or WSL) without issues. We suggest [installing WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) 
-when you want to run this package on Windows.
+Due to platform constraints, this library provides only limited support for
+spawning child processes on Windows. In particular, PHP does not allow accessing
+standard I/O pipes without blocking. As such, this project will not allow
+constructing a child process with the default process pipes and will instead
+throw a `LogicException` on Windows by default:
+
+```php
+// throws LogicException on Windows
+$process = new Process('ping example.com');
+$process->start($loop);
+```
+
+There are a number of alternatives and workarounds as detailed below if you want
+to run a child process on Windows, each with its own set of pros and cons:
+
+*   This package does work on
+    [`Windows Subsystem for Linux`](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)
+    (or WSL) without issues. When you are in control over how your application is
+    deployed, we recommend [installing WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide)
+    when you want to run this package on Windows.
+
+*   If you only care about the exit code of a child process to check if its
+    execution was successful, you can use [custom pipes](#custom-pipes) to omit
+    any standard I/O pipes like this:
+
+    ```php
+    $process = new Process('ping example.com', null, null, array());
+    $process->start($loop);
+
+    $process->on('exit', function ($exitcode) {
+        echo 'exit with ' . $exitcode . PHP_EOL;
+    });
+    ```
+
+    Similarly, this is also useful if your child process communicates over
+    sockets with remote servers or even your parent process using the
+    [Socket component](https://github.com/reactphp/socket). This is usually
+    considered the best alternative if you have control over how your child
+    process communicates with the parent process.
+
+*   If you only care about command output after the child process has been
+    executed, you can use [custom pipes](#custom-pipes) to configure file
+    handles to be passed to the child process instead of pipes like this:
+
+    ```php
+    $process = new Process('ping example.com', null, null, array(
+        array('file', 'nul', 'r'),
+        $stdout = tmpfile(),
+        array('file', 'nul', 'w')
+    ));
+    $process->start($loop);
+
+    $process->on('exit', function ($exitcode) use ($stdout) {
+        echo 'exit with ' . $exitcode . PHP_EOL;
+
+        // rewind to start and then read full file (demo only, this is blocking).
+        // reading from shared file is only safe if you have some synchronization in place
+        // or after the child process has terminated.
+        rewind($stdout);
+        echo stream_get_contents($stdout);
+        fclose($stdout);
+    });
+    ```
+
+    Note that this example uses `tmpfile()`/`fopen()` for illustration purposes only.
+    This should not be used in a truly async program because the filesystem is
+    inherently blocking and each call could potentially take several seconds.
+    See also the [Filesystem component](https://github.com/reactphp/filesystem) as an
+    alternative.
+
+*   If you want to access command output as it happens in a streaming fashion,
+    you can use redirection to spawn an additional process to forward your
+    standard I/O streams to a socket and use [custom pipes](#custom-pipes) to
+    omit any actual standard I/O pipes like this:
+
+    ```php
+    $server = new React\Socket\Server('127.0.0.1:0', $loop);
+    $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
+        $connection->on('data', function ($chunk) {
+            echo $chunk;
+        });
+    });
+
+    $command = 'ping example.com | foobar ' . escapeshellarg($server->getAddress());
+    $process = new Process($command, null, null, array());
+    $process->start($loop);
+
+    $process->on('exit', function ($exitcode) use ($server) {
+        $server->close();
+        echo 'exit with ' . $exitcode . PHP_EOL;
+    });
+    ```
+
+    Note how this will spawn another fictional `foobar` helper program to consume
+    the standard output from the actual child process. This is in fact similar
+    to the above recommendation of using socket connections in the child process,
+    but in this case does not require modification of the actual child process.
+
+    In this example, the fictional `foobar` helper program can be implemented by
+    simply consuming all data from standard input and forwarding it to a socket
+    connection like this:
+
+    ```php
+    $socket = stream_socket_client($argv[1]);
+    do {
+        fwrite($socket, $data = fread(STDIN, 8192));
+    } while (isset($data[0]));
+    ```
+
+    Accordingly, this example can also be run with plain PHP without having to
+    rely on any external helper program like this:
+
+    ```php
+    $code = '$s=stream_socket_client($argv[1]);do{fwrite($s,$d=fread(STDIN, 8192));}while(isset($d[0]));';
+    $command = 'ping example.com | php -r ' . escapeshellarg($code) . ' ' . escapeshellarg($server->getAddress());
+    $process = new Process($command, null, null, array());
+    $process->start($loop);
+    ```
+
+    See also [example #23](examples/23-forward-socket.php).
+
+    Note that this is for illustration purposes only and you may want to implement
+    some proper error checks and/or socket verification in actual production use
+    if you do not want to risk other processes connecting to the server socket.
+    In this case, we suggest looking at the excellent
+    [createprocess-windows](https://github.com/cubiclesoft/createprocess-windows).
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35",
+        "react/socket": "^1.0",
         "sebastian/environment": "^3.0 || ^2.0 || ^1.0"
     },
     "autoload": {

--- a/examples/01-stdio.php
+++ b/examples/01-stdio.php
@@ -5,6 +5,10 @@ use React\ChildProcess\Process;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('Process pipes not supported on Windows' . PHP_EOL);
+}
+
 $loop = Factory::create();
 
 $process = new Process('cat');

--- a/examples/02-race.php
+++ b/examples/02-race.php
@@ -5,6 +5,10 @@ use React\ChildProcess\Process;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('Process pipes not supported on Windows' . PHP_EOL);
+}
+
 $loop = Factory::create();
 
 $first = new Process('sleep 2; echo welt');

--- a/examples/03-stdout-stderr.php
+++ b/examples/03-stdout-stderr.php
@@ -5,6 +5,10 @@ use React\ChildProcess\Process;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('Process pipes not supported on Windows' . PHP_EOL);
+}
+
 $loop = Factory::create();
 
 $process = new Process('echo hallo;sleep 1;echo welt >&2;sleep 1;echo error;sleep 1;nope');

--- a/examples/04-terminate.php
+++ b/examples/04-terminate.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 
 // start a process that takes 10s to terminate
-$process = new Process('sleep 10');
+$process = new Process('php -r "sleep(10);"', null, null, array());
 $process->start($loop);
 
 // report when process exits

--- a/examples/11-benchmark-read.php
+++ b/examples/11-benchmark-read.php
@@ -9,6 +9,10 @@ use React\ChildProcess\Process;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('Process pipes not supported on Windows' . PHP_EOL);
+}
+
 $cmd = isset($argv[1]) ? implode(' ', array_slice($argv, 1)) : 'dd if=/dev/zero bs=1M count=1000';
 
 $loop = Factory::create();

--- a/examples/12-benchmark-write.php
+++ b/examples/12-benchmark-write.php
@@ -2,9 +2,12 @@
 
 use React\EventLoop\Factory;
 use React\ChildProcess\Process;
-use React\Stream\Stream;
 
 require __DIR__ . '/../vendor/autoload.php';
+
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('Process pipes not supported on Windows' . PHP_EOL);
+}
 
 $loop = Factory::create();
 

--- a/examples/13-benchmark-throughput.php
+++ b/examples/13-benchmark-throughput.php
@@ -2,9 +2,12 @@
 
 use React\EventLoop\Factory;
 use React\ChildProcess\Process;
-use React\Stream\Stream;
 
 require __DIR__ . '/../vendor/autoload.php';
+
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('Process pipes not supported on Windows' . PHP_EOL);
+}
 
 $loop = Factory::create();
 

--- a/examples/21-fds.php
+++ b/examples/21-fds.php
@@ -5,6 +5,10 @@ use React\ChildProcess\Process;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('Process pipes not supported on Windows' . PHP_EOL);
+}
+
 $loop = Factory::create();
 
 $process = new Process('exec 0>&- 2>&-;exec ls -la /proc/self/fd', null, null, array(

--- a/examples/22-race-exit.php
+++ b/examples/22-race-exit.php
@@ -1,0 +1,24 @@
+<?php
+
+use React\EventLoop\Factory;
+use React\ChildProcess\Process;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+
+$first = new Process('php -r "sleep(2);"', null, null, array());
+$first->start($loop);
+
+$first->on('exit', function ($code) {
+    echo 'First closed ' . $code . PHP_EOL;
+});
+
+$second = new Process('php -r "sleep(1);"', null, null, array());
+$second->start($loop);
+
+$second->on('exit', function ($code) {
+    echo 'Second closed ' . $code . PHP_EOL;
+});
+
+$loop->run();

--- a/examples/23-forward-socket.php
+++ b/examples/23-forward-socket.php
@@ -1,0 +1,42 @@
+<?php
+
+use React\EventLoop\Factory;
+use React\ChildProcess\Process;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+
+$server = new React\Socket\Server('127.0.0.1:0', $loop);
+$server->on('connection', function (React\Socket\ConnectionInterface $connection) {
+    $connection->on('data', function ($chunk) {
+        // escape control codes (useful in case encoding or binary data is not working as expected)
+        // $chunk = addcslashes($chunk,"\0..\37!@\177..\377");
+
+        // convert default code page 850 to UTF-8 (German Windows in this case)
+        $chunk = iconv('CP850','UTF-8', $chunk);
+
+        echo $chunk;
+    });
+});
+
+$command = 'php -r "echo 1;sleep(1);echo 2;sleep(1);echo 3;"';
+// $command = 'ping google.com';
+// $command = 'C:\Windows\System32\ping google.com';
+
+// use stream redirections to consume output of child process in another helper process and forward to socket
+$code = '$s=stream_socket_client($argv[1]);do{fwrite($s,$d=fread(STDIN, 8192));}while(isset($d[0]));';
+$process = new Process(
+    $command . ' | php -r ' . escapeshellarg($code) . ' ' . $server->getAddress(),
+    null,
+    null,
+    array()
+);
+$process->start($loop);
+
+$process->on('exit', function ($code) use ($server) {
+    $server->close();
+    echo PHP_EOL . 'Process closed ' . $code . PHP_EOL;
+});
+
+$loop->run();

--- a/src/Process.php
+++ b/src/Process.php
@@ -75,10 +75,6 @@ class Process extends EventEmitter
     */
     public function __construct($cmd, $cwd = null, array $env = null, array $fds = null)
     {
-        if (substr(strtolower(PHP_OS), 0, 3) === 'win') {
-            throw new \LogicException('Windows isn\'t supported due to the blocking nature of STDIN/STDOUT/STDERR pipes.');
-        }
-
         if (!function_exists('proc_open')) {
             throw new \LogicException('The Process class relies on proc_open(), which is not available on your PHP installation.');
         }
@@ -99,6 +95,14 @@ class Process extends EventEmitter
                 array('pipe', 'w'), // stdout
                 array('pipe', 'w'), // stderr
             );
+        }
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            foreach ($fds as $fd) {
+                if (isset($fd[0]) && $fd[0] === 'pipe') {
+                    throw new \LogicException('Process pipes are not supported on Windows due to their blocking nature on Windows');
+                }
+            }
         }
 
         $this->fds = $fds;

--- a/src/Process.php
+++ b/src/Process.php
@@ -145,7 +145,15 @@ class Process extends EventEmitter
             $cmd = sprintf('(%s) ' . $sigchild . '>/dev/null; code=$?; echo $code >&' . $sigchild . '; exit $code', $cmd);
         }
 
-        $this->process = proc_open($cmd, $fdSpec, $pipes, $this->cwd, $this->env);
+        // on Windows, we do not launch the given command line in a shell (cmd.exe) by default and omit any error dialogs
+        // the cmd.exe shell can explicitly be given as part of the command as detailed in both documentation and tests
+        $options = array();
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $options['bypass_shell'] = true;
+            $options['suppress_errors'] = true;
+        }
+
+        $this->process = proc_open($cmd, $fdSpec, $pipes, $this->cwd, $this->env, $options);
 
         if (!is_resource($this->process)) {
             throw new \RuntimeException('Unable to launch a new process.');


### PR DESCRIPTION
This PR adds limited Windows support by omitting any process I/O pipes on Windows. While this means that portability might be limited, it at least allows spawning processes on Windows. Also, this PR includes plenty of tests and documentation for known workarounds, so one can in fact process output using I/O redirections. This has been tested extensively on some Windows 10 installations, but this repository does not currently run any tests on Windows. I consider this to be out of scope for this ticket, but agree that it makes sense to look into test automation in a follow-up PR. In the meantime, you're invited to run this on your local Windows installation or take my word for granted, so now let's get this shipped! :shipit: :heart: 

Resolves / closes #9 
Builds on top of #65