### PR TITLE
[WIP] Run tests on Mac OS X and Windows on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,17 @@ matrix:
       before_install:
       - brew install php || brew install php # retry if it doesn't work on first try
       - brew install composer
+    - name: "Windows"
+      os: windows
+      language: shell # no built-in php support
+      before_install:
+        - choco install php
+        - choco install composer
+        - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
   allow_failures:
     - php: hhvm
     - os: osx
+    - os: windows
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,15 @@ matrix:
       dist: precise
     - php: hhvm
       install: composer require phpunit/phpunit:^5 --dev --no-interaction
+    - name: "Mac OS X"
+      os: osx
+      language: generic # no built-in php support
+      before_install:
+      - brew install php || brew install php # retry if it doesn't work on first try
+      - brew install composer
   allow_failures:
     - php: hhvm
+    - os: osx
 
 sudo: false
 


### PR DESCRIPTION
This PR adds Mac OS X and Windows to the test matrix on Travis CI. Most of this project should work cross-platform, but we've added some Windows-specifics with #67, so we have reason to believe that tests help us ensure we do not introduce any regressions in the future.

Both platforms are currently allowed to fail, given how we've tried to add similar tests in the past (#21 and #28) and also given that Windows platform support on Travis is currently considered "early release" (https://blog.travis-ci.com/2018-10-11-windows-early-release) and the test setup contains some workarounds. I consider this to be a first step and there's hope we can build on top of this in the future :+1: 

Builds on top of #67
Refs https://github.com/reactphp/stream/pull/120 and https://github.com/reactphp/stream/pull/112