### PR TITLE
Run tests on Windows via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,16 @@ matrix:
       dist: precise
     - php: hhvm
       install: composer require phpunit/phpunit:^5 --dev --no-interaction
+    - name: "Windows"
+      os: windows
+      language: shell # no built-in php support
+      before_install:
+        - choco install php
+        - choco install composer
+        - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
   allow_failures:
     - php: hhvm
+    - os: windows
 
 sudo: false
 


### PR DESCRIPTION
This PR adds Windows to the test matrix on Travis CI. Most of this project should work cross-platform, but we've added some Windows-specifics with #67, so we have reason to believe that tests help us ensure we do not introduce any regressions in the future.

Windows platform tests are currently allowed to fail, given how we've tried to add similar tests in the past (#21, #28 and #70) and also given that Windows platform support on Travis is currently considered "early release" (https://blog.travis-ci.com/2018-10-11-windows-early-release) and the test setup contains some workarounds. I consider this to be a first step and there's hope we can build on top of this in the future :+1: 

Credit where credit is due: Thanks @Lekensteyn for the detailed post in https://travis-ci.community/t/feedback-from-windows-integration-for-a-cmake-qt-c-python-perl-project/1706 which helped me immensely (spawning a powershell to read the updated PATH environment).

Builds on top of #67
Refs https://github.com/reactphp/stream/pull/120 and https://github.com/reactphp/stream/pull/112