### PR TITLE
Add process interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ as [Streams](https://github.com/reactphp/stream).
 **Table of contents**
 
 * [Quickstart example](#quickstart-example)
+* [Process Interface](#process-interface)
+  * [Pipes](#pipes)
+  * [Events](#events)
 * [Process](#process)
   * [Stream Properties](#stream-properties)
   * [Command](#command)
@@ -46,6 +49,38 @@ $loop->run();
 ```
 
 See also the [examples](examples).
+
+## Process Interface
+
+The `ProcessInterface` interface defines a minimal public interface on how you can
+interact with the process, as different implementations provide different
+APIs and features. How the process has to be created is not detailed, as different
+implementations have different mechanism.
+
+### Pipes
+
+Even though pipe creations are implementation details, getting opened pipes are
+standardized through four method interfaces:
+
+```php
+function getStdin(): WritableStreamInterface|DuplexStreamInterface|null;
+function getStdout(): ReadableStreamInterface|DuplexStreamInterface|null;
+function getStderr(): ReadableStreamInterface|DuplexStreamInterface|null;
+function getPipes(): array<ReadableStreamInterface|WritableStreamInterface|DuplexStreamInterface>;
+```
+
+### Events
+
+The process interface extends the `EventEmitterInterface` to be able to emit events,
+to achieve reactions to child process deaths as bare minimum.
+
+#### Exit event
+
+The `exit` event will be emitted whenever the process is no longer running.
+Event listeners will receive the exit code and termination signal as two
+nullable integer arguments.
+
+When you receive which values depends on the Child Process implementation.
 
 ## Process
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -4,6 +4,7 @@ namespace React\ChildProcess;
 
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
+use React\Stream\DuplexStreamInterface;
 use React\Stream\ReadableResourceStream;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableResourceStream;
@@ -53,7 +54,7 @@ use React\Stream\WritableStreamInterface;
  *     Accordingly, if either of these pipes is in a paused state (`pause()` method
  *     or internally due to a `pipe()` call), this detection may not trigger.
  */
-class Process extends EventEmitter
+class Process extends EventEmitter implements ProcessInterface
 {
     /**
      * @var WritableStreamInterface|null|ReadableStreamInterface
@@ -79,7 +80,7 @@ class Process extends EventEmitter
      * - 1: STDOUT (`ReadableStreamInterface`)
      * - 2: STDERR (`ReadableStreamInterface`)
      *
-     * @var ReadableStreamInterface|WritableStreamInterface
+     * @var ReadableStreamInterface[]|WritableStreamInterface[]|DuplexStreamInterface[]
      */
     public $pipes = array();
 
@@ -143,6 +144,46 @@ class Process extends EventEmitter
 
         $this->fds = $fds;
         $this->enhanceSigchildCompatibility = self::isSigchildEnabled();
+    }
+
+    /**
+     * Get the stdin pipe stream of the process, or null if none created.
+     *
+     * @return WritableStreamInterface|DuplexStreamInterface|null
+     */
+    public function getStdin()
+    {
+        return $this->stdin;
+    }
+
+    /**
+     * Get the stdout pipe stream of the process, or null if none created.
+     *
+     * @return ReadableStreamInterface|DuplexStreamInterface|null
+     */
+    public function getStdout()
+    {
+        return $this->stdout;
+    }
+
+    /**
+     * Get the stderr pipe stream of the process, or null if none created.
+     *
+     * @return ReadableStreamInterface|DuplexStreamInterface|null
+     */
+    public function getStderr()
+    {
+        return $this->stderr;
+    }
+
+    /**
+     * Get all created pipes as array.
+     *
+     * @return ReadableStreamInterface[]|WritableStreamInterface[]|DuplexStreamInterface[]
+     */
+    public function getPipes()
+    {
+        return $this->pipes;
     }
 
     /**

--- a/src/ProcessInterface.php
+++ b/src/ProcessInterface.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace React\ChildProcess;
+
+use Evenement\EventEmitterInterface;
+use React\EventLoop\LoopInterface;
+use React\Stream\DuplexStreamInterface;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+
+/**
+ * This process interface defines a common public interface
+ * for all child process implementations to guarantee
+ * inter-compatibility.
+ *
+ * This interface does not define how a process is created,
+ * instead it defines a layer how to interact with it.
+ *
+ * The event emitter interface is used to emit events to be able
+ * to react to events (such as process exit).
+ *
+ * The minimum required event is the `exit` event, that
+ * notifies the user of the death of a child process.
+ * The arguments are the exit code and termination signal
+ * (as nullable integers).
+ */
+interface ProcessInterface extends EventEmitterInterface
+{
+    /**
+     * Get the stdin pipe stream of the process, or null if none created.
+     *
+     * @return WritableStreamInterface|DuplexStreamInterface|null
+     */
+    public function getStdin();
+
+    /**
+     * Get the stdout pipe stream of the process, or null if none created.
+     *
+     * @return ReadableStreamInterface|DuplexStreamInterface|null
+     */
+    public function getStdout();
+
+    /**
+     * Get the stderr pipe stream of the process, or null if none created.
+     *
+     * @return ReadableStreamInterface|DuplexStreamInterface|null
+     */
+    public function getStderr();
+
+    /**
+     * Get all created pipes as array.
+     *
+     * @return ReadableStreamInterface[]|WritableStreamInterface[]|DuplexStreamInterface[]
+     */
+    public function getPipes();
+
+    /**
+     * Starts the process.
+     *
+     * @param LoopInterface $loop
+     * @return void
+     */
+    public function start(LoopInterface $loop);
+
+    /**
+     * Terminate the process with an optional signal.
+     *
+     * @param int $signal Optional signal (default: SIGTERM).
+     * @return bool  Whether the signal was sent.
+     */
+    public function terminate($signal = 15);
+
+    /**
+     * Get the process ID, or null if not started or terminated.
+     *
+     * @return int|null
+     */
+    public function getPid();
+
+    /**
+     * Get the exit code returned by the process.
+     *
+     * @return int|null
+     */
+    public function getExitCode();
+
+    /**
+     * Get the signal that caused the process to terminate its execution.
+     *
+     * @return int|null
+     */
+    public function getTermSignal();
+
+    /**
+     * Returns whether the process is still running.
+     *
+     * @return bool
+     */
+    public function isRunning();
+
+    /**
+     * Returns whether the process has been terminated by an uncaught signal.
+     *
+     * @return bool
+     */
+    public function isTerminated();
+}

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\ChildProcess;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use React\ChildProcess\Process;
+use React\EventLoop\Factory;
 use SebastianBergmann\Environment\Runtime;
 
 abstract class AbstractProcessTest extends TestCase
@@ -13,9 +14,151 @@ abstract class AbstractProcessTest extends TestCase
 
     public function testGetCommand()
     {
-        $process = new Process('echo foo', null, null, array());
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd, null, null, array());
 
-        $this->assertSame('echo foo', $process->getCommand());
+        $this->assertSame($cmd, $process->getCommand());
+    }
+
+    public function testGetStdin()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+        $process->start($this->createLoop());
+
+        $this->assertInstanceOf('React\Stream\WritableStreamInterface', $process->getStdin());
+    }
+
+    public function testGetStdinEmptyPipes()
+    {
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd, null, null, array());
+        $process->start($this->createLoop());
+
+        $this->assertNull($process->getStdin());
+    }
+
+    public function testGetStdinNotStarted()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+
+        $this->assertNull($process->getStdin());
+    }
+
+    public function testGetStdout()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+        $process->start($this->createLoop());
+
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $process->getStdout());
+    }
+
+    public function testGetStdoutEmptyPipes()
+    {
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd, null, null, array());
+        $process->start($this->createLoop());
+
+        $this->assertNull($process->getStdout());
+    }
+
+    public function testGetStdoutNotStarted()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+
+        $this->assertNull($process->getStdout());
+    }
+
+    public function testGetStderr()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+        $process->start($this->createLoop());
+
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $process->getStderr());
+    }
+
+    public function testGetStderrEmptyPipes()
+    {
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd, null, null, array());
+        $process->start($this->createLoop());
+
+        $this->assertNull($process->getStderr());
+    }
+
+    public function testGetSterrNotStarted()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+
+        $this->assertNull($process->getStderr());
+    }
+
+    public function testGetPipes()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+        $process->start($this->createLoop());
+
+        $pipes = $process->getPipes();
+        $this->assertCount(3, $pipes);
+
+        $this->assertInstanceOf('React\Stream\WritableStreamInterface', $pipes[0]);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $pipes[1]);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $pipes[2]);
+    }
+
+    public function testGetPipesEmptyPipes()
+    {
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd, null, null, array());
+        $process->start($this->createLoop());
+
+        $this->assertSame(array(), $process->getPipes());
+    }
+
+    public function testGetPipesNotStarted()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $cmd = (DIRECTORY_SEPARATOR === '\\' ? 'cmd.exe /C echo foo >nul' : 'echo foo >/dev/null');
+        $process = new Process($cmd);
+
+        $this->assertSame(array(), $process->getPipes());
     }
 
     public function testPipesWillBeUnsetBeforeStarting()


### PR DESCRIPTION
This PR adds a `ProcessInterface` with a minimum API to interact with the process. Process creation is not detailed, as it's an implementation detail. A `ProcessLauncher` which can utilize different implementations would be a better method here.

Minimal documentation added to the readme, feel free to suggest extensions and changes.