### PR TITLE
Update docblock for Process::$pipes

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -79,7 +79,7 @@ class Process extends EventEmitter
      * - 1: STDOUT (`ReadableStreamInterface`)
      * - 2: STDERR (`ReadableStreamInterface`)
      *
-     * @var ReadableStreamInterface|WritableStreamInterface
+     * @var array<ReadableStreamInterface|WritableStreamInterface>
      */
     public $pipes = array();
 


### PR DESCRIPTION
Found this when running [Psalm](https://psalm.dev/) in a project of mine that is using `reactphp/child-process`.
```
Possibly undesired iteration over regular object React\Stream\ReadableStreamInterface
```
for the code:
```
foreach ($this->process->pipes as $pipe) {
```

The docblock now better reflects the fact that `$pipes` is an array of either `ReadableStreamInterface` or `WritableStreamInterface`.