### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,21 @@
 language: php
 
-php:
-# - 5.3 # requires old distro, see below
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4  
-# - hhvm # requires legacy phpunit & ignore errors, see below
-
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
-    - php: hhvm
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm-3.18
       install: composer require phpunit/phpunit:^5 --dev --no-interaction
     - name: "Windows"
       os: windows
@@ -29,14 +25,13 @@ matrix:
         - choco install composer
         - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
   allow_failures:
-    - php: hhvm
+    - php: hhvm-3.18
     - os: windows
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi
   - php examples/13-benchmark-throughput.php

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
         "react/stream": "^1.0 || ^0.7.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35",
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
         "react/socket": "^1.0",
-        "sebastian/environment": "^3.0 || ^2.0 || ^1.0"
+        "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
     },
     "autoload": {
         "psr-4": { "React\\ChildProcess\\": "src" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
->
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -84,10 +84,6 @@ abstract class AbstractProcessTest extends TestCase
         $this->assertInstanceOf('React\Stream\WritableStreamInterface', $process->pipes[3]);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage No such file or directory
-     */
     public function testStartWithInvalidFileDescriptorPathWillThrow()
     {
         $fds = array(
@@ -95,6 +91,8 @@ abstract class AbstractProcessTest extends TestCase
         );
 
         $process = new Process('exit 0', null, null, $fds);
+
+        $this->setExpectedException('RuntimeException', 'No such file or directory');
         $process->start($this->createLoop());
     }
 
@@ -130,7 +128,7 @@ abstract class AbstractProcessTest extends TestCase
             // clear dummy files handles to make some room again (avoid fatal errors for autoloader)
             $fds = array();
 
-            $this->assertContains('Too many open files', $e->getMessage());
+            $this->assertContainsString('Too many open files', $e->getMessage());
         }
     }
 
@@ -631,9 +629,6 @@ abstract class AbstractProcessTest extends TestCase
         $this->assertNotEmpty($output);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testStartAlreadyRunningProcess()
     {
         if (DIRECTORY_SEPARATOR === '\\') {
@@ -645,6 +640,8 @@ abstract class AbstractProcessTest extends TestCase
         //var_dump($process);
 
         $process->start($this->createLoop());
+
+        $this->setExpectedException('RuntimeException');
         $process->start($this->createLoop());
     }
 
@@ -872,5 +869,33 @@ abstract class AbstractProcessTest extends TestCase
         $runtime = new Runtime();
 
         return $runtime->getBinary();
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
+
+    public function assertContainsString($needle, $haystack)
+    {
+        if (method_exists($this, 'assertStringContainsString')) {
+            // PHPUnit 7.5+
+            $this->assertStringContainsString($needle, $haystack);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.5
+            $this->assertContains($needle, $haystack);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file because the new format is unknown for them.
For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).

It's also possible to run this code with PHP 8 (without extension) 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0 php vendor/bin/phpunit
PHPUnit 9.5.1 by Sebastian Bergmann and contributors.

..SSSSSSSSSSSSSSSSSSSSSSSSSSSS.SSSS..SSSSSSSSSSSSSSSSSSSSSSSSSS  63 / 140 ( 45%)
SS.SSSS..SSSSSSSSSSSSSSSSSSSSSSSSSSSS.SSSS..................... 126 / 140 ( 90%)
...........SS.                                                  140 / 140 (100%)

Time: 00:05.394, Memory: 450.01 MB

OK, but incomplete, skipped, or risky tests!
Tests: 140, Assertions: 88, Skipped: 98.
```