### PR TITLE
Skip sigchild check if `phpinfo()` has been disabled

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -438,6 +438,10 @@ class Process extends EventEmitter
             return self::$sigchild;
         }
 
+        if (!\function_exists('phpinfo')) {
+            return self::$sigchild = false; // @codeCoverageIgnore
+        }
+
         \ob_start();
         \phpinfo(INFO_GENERAL);
 


### PR DESCRIPTION
This can be tested like this:

```php
$ php -d disable_functions=phpinfo vendor/bin/phpunit
```

Resolves / closes #88
Refs https://github.com/symfony/symfony/pull/10285