### PR TITLE
Fix legacy HHVM build by downgrading Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
+      - run: composer self-update --2.2 # downgrade Composer for HHVM
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit
       - run: hhvm examples/13-benchmark-throughput.php

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChildProcess
 
-[![CI status](https://github.com/reactphp/child-process/workflows/CI/badge.svg)](https://github.com/reactphp/child-process/actions)
+[![CI status](https://github.com/reactphp/child-process/actions/workflows/ci.yml/badge.svg)](https://github.com/reactphp/child-process/actions)
 [![installs on Packagist](https://img.shields.io/packagist/dt/react/child-process?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/react/child-process)
 
 Event-driven library for executing child processes with


### PR DESCRIPTION
Builds on top of the work done by @clue and the discussion inside reactphp/socket#289.

I also updated the path for the CI badge.