### PR TITLE
Skip failing tests on bugged versions (PHP 8.1.8)

### DIFF
--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -643,7 +643,7 @@ abstract class AbstractProcessTest extends TestCase
             $this->markTestSkipped('Process pipes not supported on Windows');
         }
 
-        if (PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
+        if (PHP_VERSION_ID === 80108 || PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
             $this->markTestSkipped('Skip bugged PHP version: https://github.com/php/php-src/issues/8827');
         }
 
@@ -673,7 +673,7 @@ abstract class AbstractProcessTest extends TestCase
      */
     public function testDetectsClosingStdoutSocketWithoutHavingToWaitForExit()
     {
-        if (PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
+        if (PHP_VERSION_ID === 80108 || PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
             $this->markTestSkipped('Skip bugged PHP version: https://github.com/php/php-src/issues/8827');
         }
 
@@ -711,7 +711,7 @@ abstract class AbstractProcessTest extends TestCase
             $this->markTestSkipped('Process pipes not supported on Windows');
         }
 
-        if (PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
+        if (PHP_VERSION_ID === 80108 || PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
             $this->markTestSkipped('Skip bugged PHP version: https://github.com/php/php-src/issues/8827');
         }
 
@@ -750,7 +750,7 @@ abstract class AbstractProcessTest extends TestCase
      */
     public function testKeepsRunningEvenWhenAllStdioSocketsHaveBeenClosed()
     {
-        if (PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
+        if (PHP_VERSION_ID === 80108 || PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
             $this->markTestSkipped('Skip bugged PHP version: https://github.com/php/php-src/issues/8827');
         }
 


### PR DESCRIPTION
As shown in #96 already, PHP 8.1.7 and PHP 8.0.20 exhibit a test failure due to a regression introduced upstream in PHP itself (https://github.com/php/php-src/issues/8827). This was supposed to be fixed with PHP 8.1.8 and PHP 8.0.21, but it turned out the fix for PHP 8.1.8 was incomplete and thus still exhibits the same error (https://github.com/php/php-src/issues/8952). Accordingly, this should be fixed in PHP 8.1.9 and PHP 8.0.21. In the meantime, we now also skip the test for PHP 8.1.8.

Builds on top of #96