### PR TITLE
Remove legacy sigchild compatibility layer

### DIFF
--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -246,24 +246,6 @@ abstract class AbstractProcessTest extends TestCase
         $this->assertNull($process->getTermSignal());
     }
 
-    public function testCommandWithEnhancedSigchildCompatibilityReceivesExitCode()
-    {
-        if (DIRECTORY_SEPARATOR === '\\') {
-            $this->markTestSkipped('Process pipes not supported on Windows');
-        }
-
-        $loop = $this->createLoop();
-        $old = Process::isSigchildEnabled();
-        Process::setSigchildEnabled(true);
-        $process = new Process('echo foo');
-        $process->start($loop);
-        Process::setSigchildEnabled($old);
-
-        $loop->run();
-
-        $this->assertEquals(0, $process->getExitCode());
-    }
-
     public function testReceivesProcessStdoutFromEcho()
     {
         if (DIRECTORY_SEPARATOR === '\\') {


### PR DESCRIPTION
This changeset removes the legacy sigchild compatibility layer. This means that legacy platforms that use PHP compiled with the legacy `--enable-sigchild` option may not reliably determine the child process' exit code in some cases. This should not affect most installations as this configure option is not used by default and most distributions (such as Debian and Ubuntu) are known to not use this by default. This option may be used on some  installations that use [Oracle OCI8](https://www.php.net/manual/en/book.oci8.php), see `phpinfo()` output to check if your installation might be affected.

The sigchild compatibility layer has been a constant source of bugs and misunderstandings (#89, #88, #63, #60 and others) with no clear benefit as it should not affect most installations. On top of this, its implementation is poorly tested and contributes to the project's complexity to a significant degree. Furthermore, its implementation prevents some API cleanup as discussed in #72 to eventually give more control over file descriptors as originally discussed in #65, #51 and others.

As such, I would like to propose removing this option for now to see how relevant this option is. This is a BC break, but empirical evidence suggests this should not affect most consumers. I'm open to the idea of reintroducing this feature once we have a better understanding how this is used in the wild and how we could safely integrate this again.