### PR TITLE
fix: prevent `Process::close()` double execution

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -297,6 +297,9 @@ class Process extends EventEmitter
             return;
         }
 
+        $process = $this->process;
+        $this->process = null;
+
         foreach ($this->pipes as $pipe) {
             $pipe->close();
         }
@@ -306,8 +309,7 @@ class Process extends EventEmitter
             $this->closeExitCodePipe();
         }
 
-        $exitCode = \proc_close($this->process);
-        $this->process = null;
+        $exitCode = \proc_close($process);
 
         if ($this->exitCode === null && $exitCode !== -1) {
             $this->exitCode = $exitCode;

--- a/tests/AbstractProcessTest.php
+++ b/tests/AbstractProcessTest.php
@@ -1099,6 +1099,28 @@ abstract class AbstractProcessTest extends TestCase
         $loop->run();
     }
 
+    public function testIssue116()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Process pipes not supported on Windows');
+        }
+
+        $loop = $this->createLoop();
+        $process = new Process('exit 0');
+
+        $process->start($loop);
+
+        // through some chain
+        $process->stdout->on('close', function () use ($process) {
+            $process->close();
+        });
+
+        $process->close();
+        $loop->stop();
+
+        $this->assertFalse($process->isRunning());
+    }
+
     /**
      * Execute a callback at regular intervals until it returns successfully or
      * a timeout is reached.


### PR DESCRIPTION
Fixes #116

The `Process::close()` method contains a block introducing side effects (see https://github.com/reactphp/child-process/blob/1721e2b93d89b745664353b9cfc8f155ba8a6159/src/Process.php#L300-L302). One of the possible side effects may be a repeated call to the `Process::close()` method. Due to the deferred protection against double execution of the method (below the block with potential side effects, see https://github.com/reactphp/child-process/blob/1721e2b93d89b745664353b9cfc8f155ba8a6159/src/Process.php#L310), the `Process::close()` method may be run again. The second execution of the `Process::close()` method will work correctly, but the first will encounter an error about the absence of a resource in the `Process::$process` property (this property was set to `null` during the second execution).

With this change, the protection against double execution of the `Process::close()` method is moved to the very beginning of the method.